### PR TITLE
chore: bump version to 12.2.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengovsg/ng-file-upload",
-  "version": "12.2.14",
+  "version": "12.2.15",
   "devDependencies": {
     "grunt": "^0.4.5",
     "grunt-contrib-concat": "^0.5.1",


### PR DESCRIPTION
This PR bumps the version of this fork to 12.2.15 so we can publish to `npm` for use by other applications depending on this package.